### PR TITLE
Added encryption for public and private keys and restriciton for specific countries

### DIFF
--- a/app/code/local/Liqpay/Liqpay/etc/config.xml
+++ b/app/code/local/Liqpay/Liqpay/etc/config.xml
@@ -107,9 +107,14 @@
                 <active>1</active>
                 <model>liqpay/paymentMethod</model>
                 <title>Liqpay (www.liqpay.com)</title>
+                <allowspecific>0</allowspecific>
+                <specificcountry>UA</specificcountry>
                 <language>ru</language>
                 <sandbox>0</sandbox>
                 <liqpay_action>https://www.liqpay.com/api/checkout</liqpay_action>
+                <liqpay_public_key backend_model="adminhtml/system_config_backend_encrypted" />
+                <liqpay_private_key backend_model="adminhtml/system_config_backend_encrypted" />
+                <debug>0</debug>
             </liqpay>
         </payment>
     </default>

--- a/app/code/local/Liqpay/Liqpay/etc/system.xml
+++ b/app/code/local/Liqpay/Liqpay/etc/system.xml
@@ -47,11 +47,38 @@
                         <title translate="label">
                             <label>Title</label>
                             <frontend_type>text</frontend_type>
-                            <sort_order>30</sort_order>
+                            <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </title>
+                        <allowspecific translate="label">
+                            <label>Payment from Applicable Countries</label>
+                            <frontend_type>allowspecific</frontend_type>
+                            <sort_order>25</sort_order>
+                            <source_model>adminhtml/system_config_source_payment_allspecificcountries</source_model>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </allowspecific>
+                        <specificcountry translate="label">
+                            <label>Payment from Specific Countries</label>
+                            <frontend_type>multiselect</frontend_type>
+                            <sort_order>26</sort_order>
+                            <source_model>adminhtml/system_config_source_country</source_model>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </specificcountry>
+                        <debug translate="label">
+                            <label>Debug mode</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>30</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </debug>
                         <heading_liqpay translate="label">
                             <label>Liqpay fields</label>
                             <frontend_model>adminhtml/system_config_form_field_heading</frontend_model>
@@ -61,7 +88,8 @@
                         </heading_liqpay>
                         <liqpay_public_key translate="label">
                             <label>Public Key</label>
-                            <frontend_type>text</frontend_type>
+                            <frontend_type>obscure</frontend_type>
+                            <backend_model>adminhtml/system_config_backend_encrypted</backend_model>
                             <sort_order>40</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -70,7 +98,8 @@
                         </liqpay_public_key>
                         <liqpay_private_key translate="label">
                             <label>Private Key</label>
-                            <frontend_type>text</frontend_type>
+                            <frontend_type>obscure</frontend_type>
+                            <backend_model>adminhtml/system_config_backend_encrypted</backend_model>
                             <sort_order>50</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>


### PR DESCRIPTION
Обратите внимание!
После мерджа моего пулл-реквеста обязательно нужно пересохранить публичный и приватный ключи. После сохранения они будут отображаться в input'ах c типом "password" (также как и в модуле Paypal у Magento)

Также в своём предыдущем пулл-реквесте я забыл добавить в system.xml поле включения debug'a. Включение этой функциональности позволит отслеживать запросы Magento к Liqpay и ответы Liqpay для Magento.