### PR TITLE
fix error during di:compile: Warning: Declaration of LiqpayMagento\Li…

### DIFF
--- a/app/code/LiqpayMagento/LiqPay/Sdk/LiqPay.php
+++ b/app/code/LiqpayMagento/LiqPay/Sdk/LiqPay.php
@@ -77,10 +77,10 @@ class LiqPay extends \LiqPay
         return $this->_supportedCurrencies;
     }
 
-    public function api($path, $params = array())
+    public function api($path, $params = array(), $timeout = 5)
     {
         $params = $this->prepareParams($params);
-        return parent::api($path, $params);
+        return parent::api($path, $params, $timeout);
     }
 
     public function cnb_form($params)


### PR DESCRIPTION
…qPay\Sdk\LiqPay::api($path, $params = Array) should be compatible with LiqPay::api($path, $params = Array, $ti     meout = 5) in app/code/LiqpayMagento/LiqPay/Sdk/LiqPay.php on line 14