### PR TITLE
Fix wrong logic in check signature

### DIFF
--- a/app/code/LiqpayMagento/LiqPay/Helper/Data.php
+++ b/app/code/LiqpayMagento/LiqPay/Helper/Data.php
@@ -118,11 +118,15 @@ class Data extends AbstractHelper
     public function securityOrderCheck($data, $receivedPublicKey, $receivedSignature)
     {
         if ($this->isSecurityCheck()) {
-            $privateKey = $this->getPrivateKey();
             $publicKey = $this->getPublicKey();
+            if ($publicKey !== $receivedPublicKey) {
+                return false;
+            }            
+            
+            $privateKey = $this->getPrivateKey();
             $generatedSignature = base64_encode(sha1($privateKey . $data . $privateKey, 1));
-            return $privateKey && $publicKey
-                && $receivedSignature == $generatedSignature || $publicKey == $receivedPublicKey;
+            
+            return $receivedSignature === $generatedSignature;
         } else {
             return true;
         }


### PR DESCRIPTION
[This part](https://github.com/liqpay/plugin-magento/blob/master/app/code/LiqpayMagento/LiqPay/Helper/Data.php#L124) of code has security issue:

```php
return $privateKey && $publicKey
    && $receivedSignature == $generatedSignature || $publicKey == $receivedPublicKey; 
```

it will return true even if signature mismatch, but public keys equal. Public key can be extracted from form data (base64_decode), so it is possible to fake callback from liqpay.